### PR TITLE
make docker files work remotely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,32 @@ dev:
 infrastructure:
 	docker compose -f ./docker/infrastructure/docker-compose.yml up --build -d
 deploy:
-	docker compose -f ./docker/deploy/docker-compose.yml up --force-recreate --build 
+	docker context use replica1
+	docker compose -f ./docker/deploy/docker-compose-replica.yml up --force-recreate --build -d
+	docker context use replica2
+	docker compose -f ./docker/deploy/docker-compose-replica.yml up --force-recreate --build -d 
+	docker context use primary
+	docker compose -f ./docker/deploy/docker-compose.yml up --force-recreate --build -d
+	docker context use default
 
 down: 
-	docker compose -f ./docker/deploy/docker-compose.yml down 
 	docker compose -f ./docker/dev/docker-compose.yml down 
 	docker compose -f ./docker/test/docker-compose.yml down 
 	docker compose -f ./docker/infrastructure/docker-compose.yml down 
 
+deploy-down:
+	docker context use replica1
+	docker compose -f ./docker/deploy/docker-compose-replica.yml down
+	docker context use replica2
+	docker compose -f ./docker/deploy/docker-compose-replica.yml down
+	docker context use primary
+	docker compose -f ./docker/deploy/docker-compose.yml down
+	docker context use default
+
 doc:
 	swag init -g be/internal/controller/router.go --output be/apidocs/
+
+docker-contexts:
+	docker context create replica1 --docker host=ssh://root@172.16.5.43
+	docker context create replica2 --docker host=ssh://root@172.16.5.47
+	docker context create primary --docker host=ssh://root@172.16.5.42

--- a/docker/deploy/be/Dockerfile
+++ b/docker/deploy/be/Dockerfile
@@ -1,28 +1,19 @@
-FROM golang:1.20.2 as builder
-WORKDIR /app
-
-RUN apt update && \
-	apt upgrade -y
-
-COPY go.mod go.sum ./
-RUN go mod download && \
-	go mod verify && \
-	go mod tidy
-
-COPY . .	
-RUN mkdir -p build && \
-	go build -o build ./...
-
-FROM ubuntu:22.04
+FROM golang:1.20.2 as build
 WORKDIR /app
 
 RUN apt update && \
 	apt upgrade -y && \
 	apt-get install -y netcat
 
-COPY --from=builder /app/build/cmd .
-COPY --from=builder /app/docker/deploy/be/entrypoint.sh .
+COPY go.mod go.sum ./
+RUN go mod download && \
+	go mod verify && \
+	go mod tidy
+
+COPY . .
+RUN mkdir -p build && \
+	go build -o build ./...
 
 ENV GIN_MODE=release
 
-CMD ["sh", "./entrypoint.sh"]
+CMD ["sh", "./docker/deploy/be/entrypoint.sh"]

--- a/docker/deploy/be/entrypoint.sh
+++ b/docker/deploy/be/entrypoint.sh
@@ -1,20 +1,3 @@
 #!/bin/sh
 
-echo "Waiting for db..."
-
-while ! nc -z db 27017; do
-    sleep 0.1
-done
-
-echo "db started"
-
-
-echo "Waiting for cache..."
-
-while ! nc -z cache 6379; do
-    sleep 0.1
-done
-
-echo "cache started"
-
-./cmd
+go run ./...

--- a/docker/deploy/docker-compose-replica.yml
+++ b/docker/deploy/docker-compose-replica.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+
+  cache-slave:
+    restart: always
+    container_name: cache-slave
+    image : redis
+    ports:
+      - 0.0.0.0:6379:6379
+    command: redis-server --slaveof 172.16.5.42 6379
+
+  mongodb-replica:
+    container_name: mongodb-replica
+    image: mongo
+    ports:
+      - 0.0.0.0:27017:27017 
+    restart: always
+    command: mongod --replSet barberReplSet
+

--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -2,29 +2,85 @@ version: '3'
 services:
 
   cache:
+    restart: always
+    container_name: cache
     image : redis
     ports:
-      - 127.0.0.1:6379:6379
+      - 0.0.0.0:6379:6379
 
-  db:
+  mongodb1:
+    container_name: mongodb1
     image: mongo
     ports:
-      - 127.0.0.1:27017:27017
+      - 0.0.0.0:27017:27017 
+    restart: always
+    command: mongod --replSet barberReplSet
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh mongodb1:27017/test --quiet
+      interval: 5s
+      timeout: 15s
+      retries: 3
+      start_period: 5s
+
+  db: 
+    container_name: db
+    restart: "no"
+    image: mongo
+    depends_on:
+      mongodb1:
+        condition: service_healthy
+    command: >
+      mongosh --host mongodb1:27017 --eval 
+      '
+      db = (new Mongo("172.16.5.42:27017")).getDB("test");
+      db = (new Mongo("172.16.5.43:27017")).getDB("test");
+      db = (new Mongo("172.16.5.47:27017")).getDB("test");
+      config = {
+      "_id" : "barberReplSet",
+      "members" : [
+        {
+          "_id" : 0,
+          "host" : "172.16.5.42:27017",
+          "priority" : 5
+        },
+        {
+          "_id" : 1,
+          "host" : "172.16.5.43:27017",
+          "priority" : 3
+        },
+        {
+          "_id" : 2,
+          "host" : "172.16.5.47:27017",
+          "priority" : 1
+        }
+      ]
+      };
+      rs.initiate(config);
+      '  
 
   backend:
+    container_name: backend
+    restart: always
     build:
       dockerfile: ./docker/deploy/be/Dockerfile
       context: ../../
+    ports:
+      - 0.0.0.0:7000:8080
     depends_on:
-      - db
-      - cache
+      cache:
+        condition: service_started
+      db:
+        condition: service_completed_successfully
     environment:
       - REDIS_HOST=cache
-      - MONGO_HOST=db
+      - MONGO_HOST=mongodb1
 
   proxy:
+    container_name: proxy
     build:
       dockerfile: ./docker/deploy/proxy/Dockerfile
       context: ../../
     ports:
-      - 80:80
+      - 0.0.0.0:80:80
+    depends_on:
+      - backend

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -5,13 +5,13 @@ services:
     restart: always
     image : redis
     ports:
-      - 127.0.0.1:6379:6379
+      - 0.0.0.0:6379:6379
 
   db: 
     restart: always
     image: mongo
     ports:
-      - 127.0.0.1:27017:27017
+      - 0.0.0.0:27017:27017
 
   backend:
     restart: always
@@ -20,7 +20,7 @@ services:
       dockerfile: ./docker/dev/Dockerfile
       context: ../../
     ports:
-      - 127.0.0.1:7000:8080
+      - 0.0.0.0:7000:8080
     depends_on:
       - cache
       - db


### PR DESCRIPTION
Setup Docker deploy and the Docker contexts of the remote machines assigned for this project.

Run "make docker-contexts" before using "make deploy" for the first time. It is reccomended to setup the host's SSH key as trusted on the target machines.