### PR TITLE
Ensure engagementScore is not nil

### DIFF
--- a/be/internal/usecase/repo/analyticsadmin.go
+++ b/be/internal/usecase/repo/analyticsadmin.go
@@ -402,7 +402,11 @@ func (r *AdminAnalyticsRepo) GetEngagementShopRanking(ctx context.Context) ([]bs
 	}
 
 	for _, result := range mongoResults {
-		result["engagementScore"] = int(result["engagementScore"].(int32))
+		if result["engagementScore"] == nil {
+			result["engagementScore"] = 0
+		} else {
+			result["engagementScore"] = int(result["engagementScore"].(int32))
+		}
 	}
 
 	return mongoResults, err


### PR DESCRIPTION
Some shop may have broken engagementScores, which the backend sets to nil. Check that a shop has a valid score before converting it to int.