### PR TITLE
Fix nginx configuration file

### DIFF
--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -11,6 +11,6 @@ server {
 
     location / {
         root /usr/share/nginx/html;
-        try_files /$uri /index.html;
+        try_files $uri $uri.html $uri/ =404;
     }
 }


### PR DESCRIPTION
On build mode, react and nextjs produce pages that end with the ".html" suffix. nginx's config file desn't expect this, so ".html" must be postponed to every request.